### PR TITLE
Add secure_home variable handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ account_management_default_home_mode: '0700'
   skeleton     : /skels/foo   # Skeleton used at create   (Default : False)
   home         : "/var/foo"   # Home path  (Default : /home/username)
   shell        : "/bin/sh"    # User shell (Default : /usr/sbin/nologin)
-  secure_home  : True         # Remove home access from other
+  secure_home  : True         # Remove home access from other (Default : True)
   authorized_public_keys : [] # Public ssh keys used for authentication
   exclusive_public_keys  : False # Only listed keys exists in authorized-keys
                                  # (Default : True)

--- a/tasks/secure_home.yml
+++ b/tasks/secure_home.yml
@@ -37,3 +37,4 @@
   when:
     - "account_management_users"
     - "(item.0.state | default('present')) == 'present'"
+    - "item.0.secure_home | default(True)"


### PR DESCRIPTION
Currently the role does not honor the value of the variable secure_home.

This PR add a condition on the value of the secure_home variable, setting it by default to true to avoid a breaking change.